### PR TITLE
Add a way to populate the MDC using annotations on function parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+HELP.md
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**
+!**/src/test/**
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+

--- a/logging/README.md
+++ b/logging/README.md
@@ -17,7 +17,7 @@ fun getBook(@Mdc @PathVariable bookId: UUID): Book {
 } // after returning, the MDC will be restored to its prior state
 ```
 
-It can also be declared on nested types:
+It can also be declared on nested values of types:
 ```kotlin
 data class Book(
     @Mdc val market: String 

--- a/logging/README.md
+++ b/logging/README.md
@@ -2,7 +2,35 @@
 
 Useful logging utils.
 
-## @Masked
+## `@Mdc` and `@MdcScope`
+
+Functions can be tagged with `@MdcScope`, and its parameters with `@Mdc` in order to populate the
+[SLF4J MDC](http://logback.qos.ch/manual/mdc.html) with data, without having to manually put things in the MDC, and
+remembering to restore it afterwards.
+
+E.g.
+```kotlin
+@MdcScope
+@GetMapping("/books/{bookId}")
+fun getBook(@Mdc @PathVariable bookId: UUID): Book {
+    MDC.get("bookId") // will return whatever is in the bookId parameter
+} // after returning, the MDC will be restored to its prior state
+```
+
+It can also be declared on nested types:
+```kotlin
+data class Book(
+    @Mdc val market: String 
+)
+
+@MdcScope
+@PostMapping("/books")
+fun createBook(@RequestBody book: Book) {
+    MDC.get("market") // will return the market value of the Book object
+}
+```
+
+## `@Masked`
 
 To mask out specific fields in data classes or objects, mark the sensitive fields with the `@Masked` annotation and use 
 the `obj.toMaskedString()` extension function. Masked fields will be replaced with `***`.
@@ -27,7 +55,7 @@ Hippi(firstname=Lars, lastname=Svensson, ssn=710502-0296, age=50)
 Hippi(firstname=***, lastname=***, ssn=***, age=50)
 ```
 
-## @LogCall
+## `@LogCall`
 
 Mark methods with the `@LogCall` annotation and get all calls to it to be logged on info level.
 

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -40,7 +40,7 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
@@ -107,6 +107,11 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.0</version>
             </plugin>
         </plugins>
     </build>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -21,17 +21,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jdk8</artifactId>
-            <version>${kotlin.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-reflect</artifactId>
-            <version>${kotlin.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-aop</artifactId>
             <version>${spring.version}</version>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>logging</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
 
     <name>logging</name>
     <description>Shared lib for logging utilities</description>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -45,12 +45,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <version>${junit-jupiter.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.willowtreeapps.assertk</groupId>
             <artifactId>assertk-jvm</artifactId>
             <version>0.22</version>

--- a/logging/src/main/kotlin/com/hedvig/libs/logging/calls/LogCall.kt
+++ b/logging/src/main/kotlin/com/hedvig/libs/logging/calls/LogCall.kt
@@ -2,4 +2,4 @@ package com.hedvig.libs.logging.calls
 
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class LogCall()
+annotation class LogCall

--- a/logging/src/main/kotlin/com/hedvig/libs/logging/masking/Masked.kt
+++ b/logging/src/main/kotlin/com/hedvig/libs/logging/masking/Masked.kt
@@ -5,7 +5,7 @@ import java.util.LinkedList
 
 @Target(AnnotationTarget.FIELD)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class Masked()
+annotation class Masked
 
 fun Any?.toMaskedString(): String = when (this) {
     is Collection<*> -> this.toMaskedString()

--- a/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/Mdc.kt
+++ b/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/Mdc.kt
@@ -4,6 +4,7 @@ package com.hedvig.libs.logging.mdc
  * This can be attached to method parameters or class properties to place it inside [org.slf4j.MDC].
  * It must be combined with a [MdcScope] on the method.
  *
+ * Currently only supports tagging [String], [Int] and [java.util.UUID].
  *
  *     @GetMapping("/books/{bookId}")
  *     @MdcScope

--- a/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/Mdc.kt
+++ b/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/Mdc.kt
@@ -1,85 +1,31 @@
 package com.hedvig.libs.logging.mdc
 
-import org.aspectj.lang.ProceedingJoinPoint
-import org.aspectj.lang.reflect.MethodSignature
-import java.util.*
-import kotlin.reflect.*
-import kotlin.reflect.full.*
-import kotlin.reflect.jvm.kotlinFunction
-
-@Target(AnnotationTarget.FIELD, AnnotationTarget.VALUE_PARAMETER)
+/**
+ * This can be attached to method parameters or class properties to place it inside [org.slf4j.MDC].
+ * It must be combined with a [MdcScope] on the method.
+ *
+ *
+ *     @GetMapping("/books/{bookId}")
+ *     @MdcScope
+ *     fun getBook(@Mdc @PathVariable bookId: String): Book {
+ *       // code in here will have "bookId": "<bookId value>" set in the MDC
+ *     } // after returning, the MDC will be restored to its previous state
+ *
+ *
+ *     @PostMapping
+ *     @MdcScope
+ *     fun createBook(@RequestBody book: Book) {
+ *       // this will have the "bookId" from the Book in the MDC
+ *     }
+ *
+ *     data class Book(
+ *       @Mdc val bookId: String  // <-- will be found in the method above
+ *     )
+ *
+ * @param name The property for the MDC value. If empty, the parameter name will be used.
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class Mdc(
     val name: String = ""
 )
-
-internal fun ProceedingJoinPoint.extractMdcProperties(): Map<String, String> {
-    val signature = (signature as? MethodSignature) ?: return emptyMap()
-    val method = signature.method.kotlinFunction ?: return emptyMap()
-    return extractMdcProperties(method, args)
-}
-
-internal fun extractMdcProperties(method: KFunction<*>, args: Array<Any>): Map<String, String> {
-    val mdc = mutableMapOf<String, String>()
-    args.indices.forEach { index ->
-        val arg = args[index]
-        val parameter = method.valueParameters[index]
-        extractMdcPropertiesRecursively(arg, parameter, mdc)
-    }
-    return mdc
-}
-
-private fun extractMdcPropertiesRecursively(
-    value: Any,
-    element: KAnnotatedElement,
-    result: MutableMap<String, String>
-) {
-    // Don't try to do anything to lambdas
-    if (value is Function<*>) return
-
-    val mdcTag = element.findAnnotation<Mdc>()
-    when {
-        // String, Int and UUIDs are supported @Mdc types
-        value is String || value is Int || value is UUID -> {
-            if (mdcTag != null) {
-                val propertyName = when {
-                    mdcTag.name.isNotEmpty() -> mdcTag.name
-                    element is KParameter -> element.name ?: throw IllegalArgumentException("Parameter has no name: $element")
-                    element is KCallable<*> -> element.name
-                    else -> throw IllegalArgumentException("Unsupported element type: $element")
-                }
-                result[propertyName] = value.toString()
-            }
-        }
-        value.javaClass.packageName.startsWith("com.hedvig") -> {
-            if (mdcTag != null) {
-                throw IllegalArgumentException("@Mdc can only target String, Int or UUID")
-            }
-
-            @Suppress("UNCHECKED_CAST") // Needed to make compiler happy
-            val clazz = value::class as KClass<Any>
-
-            // In Kotlin, if you annotate properties as part of the primary constructor
-            // the annotations end up on the constructor parameters, not on the actual
-            // field or property. Therefore, we must dig them out like this.
-            // Example:
-            // data class Request(
-            //   @Mdc val taskId: UUID   <-- this is annotated on the constructor param, not the field or property
-            // )
-            // See: https://kotlinlang.org/docs/annotations.html#annotation-use-site-targets
-            val paramPropertyMatch = clazz.primaryConstructor!!.parameters.mapNotNull { param ->
-                val property = clazz.memberProperties.find { it.name == param.name } ?: return@mapNotNull null
-                param to property
-            }
-
-            for ((parameter, property) in paramPropertyMatch) {
-                val nestedValue = property.get(value) ?: continue
-                extractMdcPropertiesRecursively(
-                    nestedValue,
-                    parameter,
-                    result
-                )
-            }
-        }
-    }
-}

--- a/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/Mdc.kt
+++ b/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/Mdc.kt
@@ -4,7 +4,7 @@ package com.hedvig.libs.logging.mdc
  * This can be attached to method parameters or class properties to place it inside [org.slf4j.MDC].
  * It must be combined with a [MdcScope] on the method.
  *
- * Currently only supports tagging [String], [Int] and [java.util.UUID].
+ * Currently only supports tagging [String], [Number]s and [java.util.UUID].
  *
  *     @GetMapping("/books/{bookId}")
  *     @MdcScope

--- a/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/Mdc.kt
+++ b/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/Mdc.kt
@@ -1,0 +1,32 @@
+package com.hedvig.libs.logging.mdc
+
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.reflect.MethodSignature
+import java.lang.reflect.Method
+import kotlin.reflect.KFunction
+import kotlin.reflect.jvm.kotlinFunction
+
+@Target(AnnotationTarget.FIELD, AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Mdc(
+    val name: String = ""
+)
+
+internal fun ProceedingJoinPoint.extractMdcProperties(): Map<String, String> {
+    val signature = (signature as? MethodSignature) ?: return emptyMap()
+    val kFunction = signature.method.kotlinFunction ?: return emptyMap()
+    return extractMdcProperties(kFunction, args)
+}
+
+internal fun extractMdcProperties(method: KFunction<*>, args: Array<Any>): Map<String, String> {
+    val mdc = mutableMapOf<String, String>()
+    args.indices.forEach { index ->
+        val arg = args[index]
+        val parameter = method.parameters[index]
+        parameter.annotations.filterIsInstance<Mdc>().firstOrNull()?.let { annotation ->
+            val property = if (annotation.name.isNotBlank()) annotation.name else parameter.name ?: "arg$index"
+            mdc[property] = arg.toString()
+        }
+    }
+    return mdc
+}

--- a/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/Mdc.kt
+++ b/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/Mdc.kt
@@ -2,8 +2,9 @@ package com.hedvig.libs.logging.mdc
 
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.reflect.MethodSignature
-import kotlin.reflect.KFunction
-import kotlin.reflect.full.valueParameters
+import java.util.*
+import kotlin.reflect.*
+import kotlin.reflect.full.*
 import kotlin.reflect.jvm.kotlinFunction
 
 @Target(AnnotationTarget.FIELD, AnnotationTarget.VALUE_PARAMETER)
@@ -23,10 +24,62 @@ internal fun extractMdcProperties(method: KFunction<*>, args: Array<Any>): Map<S
     args.indices.forEach { index ->
         val arg = args[index]
         val parameter = method.valueParameters[index]
-        parameter.annotations.filterIsInstance<Mdc>().firstOrNull()?.let { annotation ->
-            val property = if (annotation.name.isNotBlank()) annotation.name else parameter.name ?: "arg$index"
-            mdc[property] = arg.toString()
-        }
+        extractMdcPropertiesRecursively(arg, parameter, mdc)
     }
     return mdc
+}
+
+private fun extractMdcPropertiesRecursively(
+    value: Any,
+    element: KAnnotatedElement,
+    result: MutableMap<String, String>
+) {
+    // Don't try to do anything to lambdas
+    if (value is Function<*>) return
+
+    val mdcTag = element.findAnnotation<Mdc>()
+    when {
+        // String, Int and UUIDs are supported @Mdc types
+        value is String || value is Int || value is UUID -> {
+            if (mdcTag != null) {
+                val propertyName = when {
+                    mdcTag.name.isNotEmpty() -> mdcTag.name
+                    element is KParameter -> element.name ?: throw IllegalArgumentException("Parameter has no name: $element")
+                    element is KCallable<*> -> element.name
+                    else -> throw IllegalArgumentException("Unsupported element type: $element")
+                }
+                result[propertyName] = value.toString()
+            }
+        }
+        value.javaClass.packageName.startsWith("com.hedvig") -> {
+            if (mdcTag != null) {
+                throw IllegalArgumentException("@Mdc can only target String, Int or UUID")
+            }
+
+            @Suppress("UNCHECKED_CAST") // Needed to make compiler happy
+            val clazz = value::class as KClass<Any>
+
+            // In Kotlin, if you annotate properties as part of the primary constructor
+            // the annotations end up on the constructor parameters, not on the actual
+            // field or property. Therefore, we must dig them out like this.
+            // Example:
+            // data class Request(
+            //   @Mdc val taskId: UUID   <-- this is annotated on the constructor param, not the field or property
+            // )
+            // See: https://kotlinlang.org/docs/annotations.html#annotation-use-site-targets
+            val paramPropertyMatch = clazz.primaryConstructor!!.parameters.mapNotNull { param ->
+                val property = clazz.memberProperties.find { it.name == param.name } ?: return@mapNotNull null
+                param to property
+            }
+
+            for ((parameter, property) in paramPropertyMatch) {
+                val nestedValue = property.get(value) ?: continue
+                extractMdcPropertiesRecursively(
+                    nestedValue,
+                    parameter,
+                    result
+                )
+            }
+        }
+    }
 }

--- a/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/Mdc.kt
+++ b/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/Mdc.kt
@@ -2,8 +2,8 @@ package com.hedvig.libs.logging.mdc
 
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.reflect.MethodSignature
-import java.lang.reflect.Method
 import kotlin.reflect.KFunction
+import kotlin.reflect.full.valueParameters
 import kotlin.reflect.jvm.kotlinFunction
 
 @Target(AnnotationTarget.FIELD, AnnotationTarget.VALUE_PARAMETER)
@@ -14,15 +14,15 @@ annotation class Mdc(
 
 internal fun ProceedingJoinPoint.extractMdcProperties(): Map<String, String> {
     val signature = (signature as? MethodSignature) ?: return emptyMap()
-    val kFunction = signature.method.kotlinFunction ?: return emptyMap()
-    return extractMdcProperties(kFunction, args)
+    val method = signature.method.kotlinFunction ?: return emptyMap()
+    return extractMdcProperties(method, args)
 }
 
 internal fun extractMdcProperties(method: KFunction<*>, args: Array<Any>): Map<String, String> {
     val mdc = mutableMapOf<String, String>()
     args.indices.forEach { index ->
         val arg = args[index]
-        val parameter = method.parameters[index]
+        val parameter = method.valueParameters[index]
         parameter.annotations.filterIsInstance<Mdc>().firstOrNull()?.let { annotation ->
             val property = if (annotation.name.isNotBlank()) annotation.name else parameter.name ?: "arg$index"
             mdc[property] = arg.toString()

--- a/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/MdcScope.kt
+++ b/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/MdcScope.kt
@@ -1,0 +1,6 @@
+package com.hedvig.libs.logging.mdc
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class MdcScope
+

--- a/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/MdcScope.kt
+++ b/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/MdcScope.kt
@@ -1,5 +1,19 @@
 package com.hedvig.libs.logging.mdc
 
+/**
+ * This can be attached to a function to make it a scope for [org.slf4j.MDC] data, which can be declared and read
+ * directly from annotated parameters of that function.
+ *
+ * Methods tagged with [MdcScope] will search for parameters or nested properties of the parameters for the [Mdc]
+ * annotation,
+ *
+ *     @GetMapping("/books/{bookId}")
+ *     @MdcScope
+ *     fun getBook(@Mdc @PathVariable bookId: String): Book {
+ *       // code in here will have "bookId": "<bookId value>" set in the MDC
+ *     } // after returning, the MDC will be restored to its previous state
+ *
+ */
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class MdcScope

--- a/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/MdcScopeAspect.kt
+++ b/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/MdcScopeAspect.kt
@@ -29,9 +29,11 @@ class MdcScopeAspect(
             "$prefix.${it.key}"
         }
         val existing = pushMdc(newContext)
-        val result = joinPoint.proceed()
-        restoreMdc(newContext, existing)
-        return result
+        try {
+            return joinPoint.proceed()
+        } finally {
+            restoreMdc(newContext, existing)
+        }
     }
 
     private fun pushMdc(newContext: Map<String, String>): Map<String, String> {

--- a/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/MdcScopeAspect.kt
+++ b/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/MdcScopeAspect.kt
@@ -1,0 +1,40 @@
+package com.hedvig.libs.logging.mdc
+
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.slf4j.MDC
+import org.springframework.stereotype.Component
+
+@Aspect
+@Component
+class MdcScopeAspect {
+
+    @Around("@annotation(com.hedvig.libs.logging.mdc.MdcScope)")
+    fun applyMdc(joinPoint: ProceedingJoinPoint): Any? {
+        val newContext = joinPoint.extractMdcProperties()
+        val existing = pushMdc(newContext)
+        val result = joinPoint.proceed()
+        restoreMdc(newContext, existing)
+        return result
+    }
+
+    private fun pushMdc(newContext: Map<String, String>): Map<String, String> {
+        val existing = mutableMapOf<String, String>()
+        newContext.forEach { (key, value) ->
+            MDC.get(key)?.let { existing[key] = it }
+            MDC.put(key, value)
+        }
+        return existing
+    }
+
+    private fun restoreMdc(contextToDelete: Map<String, String>, contextToRestore: Map<String, String>) {
+        contextToDelete.forEach { (key, value) ->
+            contextToRestore[key]?.let { restored ->
+                MDC.put(key, restored)
+            } ?: run {
+                MDC.remove(key)
+            }
+        }
+    }
+}

--- a/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/MdcScopeAspect.kt
+++ b/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/MdcScopeAspect.kt
@@ -4,21 +4,30 @@ import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.Around
 import org.aspectj.lang.annotation.Aspect
 import org.slf4j.MDC
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
 import org.springframework.stereotype.Component
 
 /**
  * The aspect that actually extracts MDC values using the [Mdc] and [MdcScope] annotations.
+ *
+ * MDC values are logged with the given prefix, which can either be configured by creating a
+ * custom Bean of this class, or setting the `hedvig.logging.mdc.prefix` property.
  */
 @Aspect
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
-class MdcScopeAspect {
+class MdcScopeAspect(
+    @Value("\${hedvig.logging.mdc.prefix:hedvig}")
+    private val prefix: String
+) {
 
     @Around("@annotation(com.hedvig.libs.logging.mdc.MdcScope)")
     fun applyMdc(joinPoint: ProceedingJoinPoint): Any? {
-        val newContext = joinPoint.extractMdcProperties()
+        val newContext = joinPoint.extractMdcProperties().mapKeys {
+            "$prefix.${it.key}"
+        }
         val existing = pushMdc(newContext)
         val result = joinPoint.proceed()
         restoreMdc(newContext, existing)

--- a/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/MdcScopeAspect.kt
+++ b/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/MdcScopeAspect.kt
@@ -4,10 +4,13 @@ import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.Around
 import org.aspectj.lang.annotation.Aspect
 import org.slf4j.MDC
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
 import org.springframework.stereotype.Component
 
 @Aspect
 @Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
 class MdcScopeAspect {
 
     @Around("@annotation(com.hedvig.libs.logging.mdc.MdcScope)")

--- a/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/MdcScopeAspect.kt
+++ b/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/MdcScopeAspect.kt
@@ -8,6 +8,9 @@ import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
 import org.springframework.stereotype.Component
 
+/**
+ * The aspect that actually extracts MDC values using the [Mdc] and [MdcScope] annotations.
+ */
 @Aspect
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)

--- a/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/extractMdcProperties.kt
+++ b/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/extractMdcProperties.kt
@@ -1,0 +1,82 @@
+package com.hedvig.libs.logging.mdc
+
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.reflect.MethodSignature
+import java.util.*
+import kotlin.reflect.*
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.full.primaryConstructor
+import kotlin.reflect.full.valueParameters
+import kotlin.reflect.jvm.kotlinFunction
+
+internal fun ProceedingJoinPoint.extractMdcProperties(): Map<String, String> {
+    val signature = (signature as? MethodSignature) ?: return emptyMap()
+    val method = signature.method.kotlinFunction ?: return emptyMap()
+    return extractMdcProperties(method, args)
+}
+
+internal fun extractMdcProperties(method: KFunction<*>, args: Array<Any>): Map<String, String> {
+    val mdc = mutableMapOf<String, String>()
+    args.indices.forEach { index ->
+        val arg = args[index]
+        val parameter = method.valueParameters[index]
+        extractMdcPropertiesRecursively(arg, parameter, mdc)
+    }
+    return mdc
+}
+
+private fun extractMdcPropertiesRecursively(
+    value: Any,
+    element: KAnnotatedElement,
+    result: MutableMap<String, String>
+) {
+    // Don't try to do anything to lambdas
+    if (value is Function<*>) return
+
+    val mdcTag = element.findAnnotation<Mdc>()
+    when {
+        // String, Int and UUIDs are supported @Mdc types
+        value is String || value is Int || value is UUID -> {
+            if (mdcTag != null) {
+                val propertyName = when {
+                    mdcTag.name.isNotEmpty() -> mdcTag.name
+                    element is KParameter -> element.name ?: throw IllegalArgumentException("Parameter has no name: $element")
+                    element is KCallable<*> -> element.name
+                    else -> throw IllegalArgumentException("Unsupported element type: $element")
+                }
+                result[propertyName] = value.toString()
+            }
+        }
+        value.javaClass.packageName.startsWith("com.hedvig") -> {
+            if (mdcTag != null) {
+                throw IllegalArgumentException("@Mdc can only target String, Int or UUID")
+            }
+
+            @Suppress("UNCHECKED_CAST") // Needed to make compiler happy
+            val clazz = value::class as KClass<Any>
+
+            // In Kotlin, if you annotate properties as part of the primary constructor
+            // the annotations end up on the constructor parameters, not on the actual
+            // field or property. Therefore, we must dig them out like this.
+            // Example:
+            // data class Request(
+            //   @Mdc val taskId: UUID   <-- this is annotated on the constructor param, not the field or property
+            // )
+            // See: https://kotlinlang.org/docs/annotations.html#annotation-use-site-targets
+            val paramPropertyMatch = clazz.primaryConstructor!!.parameters.mapNotNull { param ->
+                val property = clazz.memberProperties.find { it.name == param.name } ?: return@mapNotNull null
+                param to property
+            }
+
+            for ((parameter, property) in paramPropertyMatch) {
+                val nestedValue = property.get(value) ?: continue
+                extractMdcPropertiesRecursively(
+                    nestedValue,
+                    parameter,
+                    result
+                )
+            }
+        }
+    }
+}

--- a/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/extractMdcProperties.kt
+++ b/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/extractMdcProperties.kt
@@ -28,22 +28,20 @@ internal fun extractMdcProperties(method: KFunction<*>, args: Array<Any>): Map<S
 
 private fun extractMdcPropertiesRecursively(
     value: Any,
-    element: KAnnotatedElement,
+    parameter: KParameter,
     result: MutableMap<String, String>
 ) {
     // Don't try to do anything to lambdas
     if (value is Function<*>) return
 
-    val mdcTag = element.findAnnotation<Mdc>()
+    val mdcTag = parameter.findAnnotation<Mdc>()
     when {
         // String, Int and UUIDs are supported @Mdc types
         value is String || value is Number || value is UUID -> {
             if (mdcTag != null) {
                 val propertyName = when {
                     mdcTag.name.isNotEmpty() -> mdcTag.name
-                    element is KParameter -> element.name ?: throw IllegalArgumentException("Parameter has no name: $element")
-                    element is KCallable<*> -> element.name
-                    else -> throw IllegalArgumentException("Unsupported element type: $element")
+                    else -> parameter.name ?: throw IllegalArgumentException("Parameter has no name: $parameter")
                 }
                 result[propertyName] = value.toString()
             }
@@ -69,11 +67,11 @@ private fun extractMdcPropertiesRecursively(
                 param to property
             }
 
-            for ((parameter, property) in paramPropertyMatch) {
+            for ((param, property) in paramPropertyMatch) {
                 val nestedValue = property.get(value) ?: continue
                 extractMdcPropertiesRecursively(
                     nestedValue,
-                    parameter,
+                    param,
                     result
                 )
             }

--- a/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/extractMdcProperties.kt
+++ b/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/extractMdcProperties.kt
@@ -37,7 +37,7 @@ private fun extractMdcPropertiesRecursively(
     val mdcTag = element.findAnnotation<Mdc>()
     when {
         // String, Int and UUIDs are supported @Mdc types
-        value is String || value is Int || value is UUID -> {
+        value is String || value is Number || value is UUID -> {
             if (mdcTag != null) {
                 val propertyName = when {
                     mdcTag.name.isNotEmpty() -> mdcTag.name
@@ -50,7 +50,7 @@ private fun extractMdcPropertiesRecursively(
         }
         value.javaClass.packageName.startsWith("com.hedvig") -> {
             if (mdcTag != null) {
-                throw IllegalArgumentException("@Mdc can only target String, Int or UUID")
+                throw IllegalArgumentException("@Mdc can only target String, Number or UUID")
             }
 
             @Suppress("UNCHECKED_CAST") // Needed to make compiler happy

--- a/logging/src/test/kotlin/com/hedvig/libs/logging/calls/LogCallTest.kt
+++ b/logging/src/test/kotlin/com/hedvig/libs/logging/calls/LogCallTest.kt
@@ -1,12 +1,9 @@
 package com.hedvig.libs.logging.calls
 
 import ch.qos.logback.classic.Logger
-import org.junit.Test
-import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.stereotype.Service
-import org.springframework.test.context.junit4.SpringRunner
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
@@ -19,14 +16,17 @@ import com.hedvig.libs.logging.mdc.Mdc
 import com.hedvig.libs.logging.mdc.MdcScope
 import com.hedvig.libs.logging.mdc.MdcScopeAspect
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.After
-import org.junit.Before
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
 import org.slf4j.LoggerFactory
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.lang.IllegalArgumentException
 
-@RunWith(SpringRunner::class)
-@SpringBootTest(classes= [LogCallAspect::class, MdcScopeAspect::class])
+@ExtendWith(SpringExtension::class)
+@SpringBootTest(classes = [LogCallAspect::class, MdcScopeAspect::class])
 @ComponentScan("com.hedvig.libs.logging.calls")
 @EnableAspectJAutoProxy
 class LogCallTest {
@@ -44,14 +44,14 @@ class LogCallTest {
 
     private lateinit var logWatcher: ListAppender<ILoggingEvent>
 
-    @Before
+    @BeforeEach
     fun setup() {
         logWatcher = ListAppender()
         logWatcher.start()
         (LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) as Logger).addAppender(logWatcher)
     }
 
-    @After
+    @AfterEach
     fun cleanup() {
         (LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) as Logger).detachAppender(logWatcher)
     }

--- a/logging/src/test/kotlin/com/hedvig/libs/logging/calls/LogCallTest.kt
+++ b/logging/src/test/kotlin/com/hedvig/libs/logging/calls/LogCallTest.kt
@@ -31,14 +31,6 @@ import java.lang.IllegalArgumentException
 @EnableAspectJAutoProxy
 class LogCallTest {
 
-    @TestConfiguration
-    internal class TestServiceImplTestContextConfiguration {
-        @Bean
-        fun testService(): TestServiceX {
-            return TestServiceX()
-        }
-    }
-
     @Autowired
     lateinit var testService: TestServiceX
 

--- a/logging/src/test/kotlin/com/hedvig/libs/logging/calls/LogCallTest.kt
+++ b/logging/src/test/kotlin/com/hedvig/libs/logging/calls/LogCallTest.kt
@@ -15,6 +15,9 @@ import ch.qos.logback.classic.spi.ILoggingEvent
 
 import ch.qos.logback.core.read.ListAppender
 import com.hedvig.libs.logging.masking.Masked
+import com.hedvig.libs.logging.mdc.Mdc
+import com.hedvig.libs.logging.mdc.MdcScope
+import com.hedvig.libs.logging.mdc.MdcScopeAspect
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
@@ -23,7 +26,7 @@ import org.slf4j.LoggerFactory
 import java.lang.IllegalArgumentException
 
 @RunWith(SpringRunner::class)
-@SpringBootTest(classes= [LogCallAspect::class])
+@SpringBootTest(classes= [LogCallAspect::class, MdcScopeAspect::class])
 @ComponentScan("com.hedvig.libs.logging.calls")
 @EnableAspectJAutoProxy
 class LogCallTest {
@@ -151,6 +154,18 @@ class LogCallTest {
         }
     }
 
+    @Test
+    fun testMdcAnnoationsAreIncluded() {
+
+        testService.logIncludingMdc(context = "abc")
+
+        with(logWatcher!!) {
+            assertThat(list.size).isEqualTo(2)
+            assertThat(list[0].mdcPropertyMap).containsEntry("context", "abc")
+
+            assertThat(list[1].mdcPropertyMap).containsEntry("context", "abc")
+        }
+    }
 }
 
 
@@ -185,6 +200,10 @@ class TestServiceX {
         throw IllegalArgumentException("Testing")
     }
 
+    @MdcScope
+    @LogCall
+    fun logIncludingMdc(@Mdc context: String) {
+    }
 }
 
 data class PojoA (

--- a/logging/src/test/kotlin/com/hedvig/libs/logging/calls/LogCallTest.kt
+++ b/logging/src/test/kotlin/com/hedvig/libs/logging/calls/LogCallTest.kt
@@ -42,12 +42,12 @@ class LogCallTest {
     @Autowired
     lateinit var testService: TestServiceX
 
-    var logWatcher: ListAppender<ILoggingEvent>? = null
+    private lateinit var logWatcher: ListAppender<ILoggingEvent>
 
     @Before
     fun setup() {
         logWatcher = ListAppender()
-        logWatcher!!.start()
+        logWatcher.start()
         (LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) as Logger).addAppender(logWatcher)
     }
 
@@ -61,7 +61,7 @@ class LogCallTest {
 
         testService.logNothing("asd")
 
-        assertThat(logWatcher!!.list).isEmpty()
+        assertThat(logWatcher.list).isEmpty()
     }
 
     @Test
@@ -69,7 +69,7 @@ class LogCallTest {
 
         testService.logCallNoParamReturningUnit()
 
-        with(logWatcher!!) {
+        with(logWatcher) {
             assertThat(list.size).isEqualTo(2)
             assertThat(list[0].level.toString()).isEqualTo("INFO")
             assertThat(list[0].loggerName).isEqualTo(TestServiceX::class.java.name + "-aop")
@@ -86,7 +86,7 @@ class LogCallTest {
 
         testService.logCallWithParamsReturningString("abc", 10)
 
-        with(logWatcher!!) {
+        with(logWatcher) {
             assertThat(list.size).isEqualTo(2)
             assertThat(list[0].level.toString()).isEqualTo("INFO")
             assertThat(list[0].loggerName).isEqualTo(TestServiceX::class.java.name + "-aop")
@@ -103,7 +103,7 @@ class LogCallTest {
 
         testService.logCallWithParamsReturningNullString("abc", 10)
 
-        with(logWatcher!!) {
+        with(logWatcher) {
             assertThat(list.size).isEqualTo(2)
             assertThat(list[0].level.toString()).isEqualTo("INFO")
             assertThat(list[0].loggerName).isEqualTo(TestServiceX::class.java.name + "-aop")
@@ -123,7 +123,7 @@ class LogCallTest {
 
         testService.logCallWithPojoParamsReturningPojo(pojoA)
 
-        with(logWatcher!!) {
+        with(logWatcher) {
             assertThat(list.size).isEqualTo(2)
             assertThat(list[0].level.toString()).isEqualTo("INFO")
             assertThat(list[0].loggerName).isEqualTo(TestServiceX::class.java.name + "-aop")
@@ -142,7 +142,7 @@ class LogCallTest {
            testService.logCallThrowingException()
         }
 
-        with(logWatcher!!) {
+        with(logWatcher) {
             assertThat(list.size).isEqualTo(2)
             assertThat(list[0].level.toString()).isEqualTo("INFO")
             assertThat(list[0].loggerName).isEqualTo(TestServiceX::class.java.name + "-aop")
@@ -159,7 +159,7 @@ class LogCallTest {
 
         testService.logIncludingMdc(context = "abc")
 
-        with(logWatcher!!) {
+        with(logWatcher) {
             assertThat(list.size).isEqualTo(2)
             assertThat(list[0].mdcPropertyMap).containsEntry("hedvig.context", "abc")
 

--- a/logging/src/test/kotlin/com/hedvig/libs/logging/calls/LogCallTest.kt
+++ b/logging/src/test/kotlin/com/hedvig/libs/logging/calls/LogCallTest.kt
@@ -161,9 +161,9 @@ class LogCallTest {
 
         with(logWatcher!!) {
             assertThat(list.size).isEqualTo(2)
-            assertThat(list[0].mdcPropertyMap).containsEntry("context", "abc")
+            assertThat(list[0].mdcPropertyMap).containsEntry("hedvig.context", "abc")
 
-            assertThat(list[1].mdcPropertyMap).containsEntry("context", "abc")
+            assertThat(list[1].mdcPropertyMap).containsEntry("hedvig.context", "abc")
         }
     }
 }

--- a/logging/src/test/kotlin/com/hedvig/libs/logging/masking/MaskedTest.kt
+++ b/logging/src/test/kotlin/com/hedvig/libs/logging/masking/MaskedTest.kt
@@ -2,7 +2,7 @@ package com.hedvig.libs.logging.masking
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 
 class MaskedTest {

--- a/logging/src/test/kotlin/com/hedvig/libs/logging/mdc/MdcScopeAspectTest.kt
+++ b/logging/src/test/kotlin/com/hedvig/libs/logging/mdc/MdcScopeAspectTest.kt
@@ -15,7 +15,10 @@ import org.springframework.test.context.junit4.SpringRunner
 import java.util.*
 
 @RunWith(SpringRunner::class)
-@SpringBootTest(classes = [MdcScopeAspect::class])
+@SpringBootTest(
+    classes = [MdcScopeAspect::class],
+    properties = ["hedvig.logging.mdc.prefix=test"]
+)
 @ComponentScan("com.hedvig.libs.logging.mdc")
 @EnableAspectJAutoProxy
 class MdcScopeAspectTest {
@@ -27,7 +30,7 @@ class MdcScopeAspectTest {
     fun `test mdc is set`() {
         val uuid = UUID.randomUUID()
         worker.withContext(taskId = uuid) {
-            assertThat(MDC.get("taskId")).isEqualTo(uuid.toString())
+            assertThat(MDC.get("test.taskId")).isEqualTo(uuid.toString())
         }
     }
 
@@ -36,18 +39,18 @@ class MdcScopeAspectTest {
         val uuid = UUID.randomUUID()
         worker.withContext(taskId = uuid) {
         }
-        assertThat(MDC.get("taskId")).isNull()
+        assertThat(MDC.get("test.taskId")).isNull()
     }
 
     @Test
     fun `test mdc is restored afterwards`() {
-        MDC.put("taskId", "previous value")
+        MDC.put("test.taskId", "previous value")
         val uuid = UUID.randomUUID()
         worker.withContext(taskId = uuid) {
-            assertThat(MDC.get("taskId")).isEqualTo(uuid.toString())
+            assertThat(MDC.get("test.taskId")).isEqualTo(uuid.toString())
         }
-        assertThat(MDC.get("taskId")).isEqualTo("previous value")
-        MDC.remove("taskId")
+        assertThat(MDC.get("test.taskId")).isEqualTo("previous value")
+        MDC.remove("test.taskId")
     }
 
     @Service

--- a/logging/src/test/kotlin/com/hedvig/libs/logging/mdc/MdcScopeAspectTest.kt
+++ b/logging/src/test/kotlin/com/hedvig/libs/logging/mdc/MdcScopeAspectTest.kt
@@ -1,0 +1,38 @@
+package com.hedvig.libs.logging.mdc
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.slf4j.MDC
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.EnableAspectJAutoProxy
+import org.springframework.stereotype.Service
+import org.springframework.test.context.junit4.SpringRunner
+import java.util.*
+
+@RunWith(SpringRunner::class)
+@SpringBootTest(classes = [MdcScopeAspect::class])
+@ComponentScan("com.hedvig.libs.logging.mdc")
+@EnableAspectJAutoProxy
+class MdcScopeAspectTest {
+
+    @Autowired
+    private lateinit var worker: SomeWorker
+
+    @Test
+    fun `test mdc propagates`() {
+        val uuid = UUID.randomUUID()
+        worker.doWork(uuid)
+    }
+
+    @Service
+    internal class SomeWorker {
+        @MdcScope
+        fun doWork(@Mdc taskId: UUID) {
+            assertThat(MDC.get("taskId")).isEqualTo(taskId.toString())
+        }
+    }
+}

--- a/logging/src/test/kotlin/com/hedvig/libs/logging/mdc/MdcTest.kt
+++ b/logging/src/test/kotlin/com/hedvig/libs/logging/mdc/MdcTest.kt
@@ -4,6 +4,7 @@ import assertk.assertThat
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import org.junit.jupiter.api.Test
+import java.util.*
 
 internal class MdcTest {
 
@@ -36,6 +37,22 @@ internal class MdcTest {
     }
 
     @Test
+    fun `one mdc value - but others are not mdc`() {
+        val uuid = UUID.randomUUID()
+        val mdc = extractMdcProperties(this::singleMdcAmongNonMdc, arrayOf(10, uuid, "Testing"))
+
+        assertThat(mdc).isEqualTo(mapOf("id" to uuid.toString()))
+    }
+
+    @Test
+    fun `nested mdc value`() {
+        val uuid = UUID.randomUUID()
+        val mdc = extractMdcProperties(this::singleRequestObject, arrayOf(Request("1234")))
+
+        assertThat(mdc).isEqualTo(mapOf("targetId" to "1234"))
+    }
+
+    @Test
     fun `mdc is stringified`() {
         val mdc = extractMdcProperties(this::singleIntValue, arrayOf(17))
 
@@ -46,5 +63,11 @@ internal class MdcTest {
     private fun singleMdcValue(@Mdc firstName: String) {}
     private fun singleMdcValueWithCustomName(@Mdc("first_name") firstName: String) {}
     private fun twoMdcValues(@Mdc firstName: String, @Mdc lastName: String) {}
+    private fun singleMdcAmongNonMdc(age: Int, @Mdc id: UUID, name: String) {}
     private fun singleIntValue(@Mdc age: Int) {}
+    private fun singleRequestObject(request: Request) {}
+
+    data class Request(
+        @Mdc val targetId: String
+    )
 }

--- a/logging/src/test/kotlin/com/hedvig/libs/logging/mdc/MdcTest.kt
+++ b/logging/src/test/kotlin/com/hedvig/libs/logging/mdc/MdcTest.kt
@@ -63,7 +63,7 @@ internal class MdcTest {
     @Test
     fun `test unsupported type`() {
         assertThrows<IllegalArgumentException> {
-            extractMdcProperties(this::misstaggedParameter, arrayOf(Request("1234")))
+            extractMdcProperties(this::mistaggedParameter, arrayOf(Request("1234")))
         }
     }
 
@@ -74,7 +74,7 @@ internal class MdcTest {
     private fun singleMdcAmongNonMdc(age: Int, @Mdc id: UUID, name: String) {}
     private fun singleIntValue(@Mdc age: Int) {}
     private fun singleRequestObject(request: Request) {}
-    private fun misstaggedParameter(@Mdc request: Request) {}
+    private fun mistaggedParameter(@Mdc request: Request) {}
 
     data class Request(
         @Mdc val targetId: String

--- a/logging/src/test/kotlin/com/hedvig/libs/logging/mdc/MdcTest.kt
+++ b/logging/src/test/kotlin/com/hedvig/libs/logging/mdc/MdcTest.kt
@@ -1,0 +1,50 @@
+package com.hedvig.libs.logging.mdc
+
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import org.junit.jupiter.api.Test
+
+internal class MdcTest {
+
+    @Test
+    fun `no mdc method should product empty map`() {
+        val mdc = extractMdcProperties(this::emptyMethod, emptyArray())
+
+        assertThat(mdc).isEmpty()
+    }
+
+    @Test
+    fun `one mdc value - should get name of property`() {
+        val mdc = extractMdcProperties(this::singleMdcValue, arrayOf("Person"))
+
+        assertThat(mdc).isEqualTo(mapOf("firstName" to "Person"))
+    }
+
+    @Test
+    fun `one mdc value - with property name override`() {
+        val mdc = extractMdcProperties(this::singleMdcValueWithCustomName, arrayOf("Person"))
+
+        assertThat(mdc).isEqualTo(mapOf("first_name" to "Person"))
+    }
+
+    @Test
+    fun `two mdc values`() {
+        val mdc = extractMdcProperties(this::twoMdcValues, arrayOf("Person", "Lastname"))
+
+        assertThat(mdc).isEqualTo(mapOf("firstName" to "Person", "lastName" to "Lastname"))
+    }
+
+    @Test
+    fun `mdc is stringified`() {
+        val mdc = extractMdcProperties(this::singleIntValue, arrayOf(17))
+
+        assertThat(mdc).isEqualTo(mapOf("age" to "17"))
+    }
+
+    private fun emptyMethod() {}
+    private fun singleMdcValue(@Mdc firstName: String) {}
+    private fun singleMdcValueWithCustomName(@Mdc("first_name") firstName: String) {}
+    private fun twoMdcValues(@Mdc firstName: String, @Mdc lastName: String) {}
+    private fun singleIntValue(@Mdc age: Int) {}
+}

--- a/logging/src/test/kotlin/com/hedvig/libs/logging/mdc/MdcTest.kt
+++ b/logging/src/test/kotlin/com/hedvig/libs/logging/mdc/MdcTest.kt
@@ -4,6 +4,8 @@ import assertk.assertThat
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.lang.IllegalArgumentException
 import java.util.*
 
 internal class MdcTest {
@@ -46,7 +48,6 @@ internal class MdcTest {
 
     @Test
     fun `nested mdc value`() {
-        val uuid = UUID.randomUUID()
         val mdc = extractMdcProperties(this::singleRequestObject, arrayOf(Request("1234")))
 
         assertThat(mdc).isEqualTo(mapOf("targetId" to "1234"))
@@ -59,6 +60,13 @@ internal class MdcTest {
         assertThat(mdc).isEqualTo(mapOf("age" to "17"))
     }
 
+    @Test
+    fun `test unsupported type`() {
+        assertThrows<IllegalArgumentException> {
+            extractMdcProperties(this::misstaggedParameter, arrayOf(Request("1234")))
+        }
+    }
+
     private fun emptyMethod() {}
     private fun singleMdcValue(@Mdc firstName: String) {}
     private fun singleMdcValueWithCustomName(@Mdc("first_name") firstName: String) {}
@@ -66,6 +74,7 @@ internal class MdcTest {
     private fun singleMdcAmongNonMdc(age: Int, @Mdc id: UUID, name: String) {}
     private fun singleIntValue(@Mdc age: Int) {}
     private fun singleRequestObject(request: Request) {}
+    private fun misstaggedParameter(@Mdc request: Request) {}
 
     data class Request(
         @Mdc val targetId: String

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,19 @@
         <github.global.server>github</github.global.server>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+    </dependencies>
+
     <distributionManagement>
         <repository>
             <id>github</id>


### PR DESCRIPTION
## What
The MDC is a powerful way to get structured data attached to subsequent method calls on the same thread. This introduces a few concepts to easily attach MDC to code.

The details on how to use it can be seen in the README updates, as well as the tests.

## Why
Logs are great, and especially so if they are rich with structured data.