### PR TITLE
Added support for masking `ResponseEntity`.

### DIFF
--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>logging</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
 
     <name>logging</name>
     <description>Shared lib for logging utilities</description>
@@ -48,6 +48,12 @@
                     <artifactId>junit</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${spring.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/logging/src/main/kotlin/com/hedvig/libs/logging/masking/Masked.kt
+++ b/logging/src/main/kotlin/com/hedvig/libs/logging/masking/Masked.kt
@@ -22,7 +22,7 @@ fun Map<*, *>?.toMaskedString(): String =
 
 private fun reflectionToString(obj: Any): String {
 
-    if (!obj.javaClass.packageName.startsWith("com.hedvig"))
+    if (!isWhitelisted(obj.javaClass))
         return obj.toString()
 
     if (obj.javaClass.isEnum())
@@ -31,7 +31,7 @@ private fun reflectionToString(obj: Any): String {
     val s = LinkedList<String>()
     var clazz: Class<in Any>? = obj.javaClass
 
-    while (clazz != null && clazz.packageName.startsWith("com.hedvig")) {
+    while (clazz != null && isWhitelisted(clazz)) {
 
         for (prop in clazz.declaredFields.filterNot { Modifier.isStatic(it.modifiers) }) {
 
@@ -47,3 +47,16 @@ private fun reflectionToString(obj: Any): String {
     }
     return "${obj.javaClass.simpleName}(${s.joinToString(", ")})"
 }
+
+private fun isWhitelisted(clazz: Class<in Any>): Boolean {
+    if (clazz.packageName.startsWith("com.hedvig")) {
+        return true
+    }
+
+    return clazz.name in whitelist
+}
+
+private val whitelist = setOf(
+    "org.springframework.http.ResponseEntity",
+    "org.springframework.http.HttpEntity"
+)

--- a/logging/src/test/kotlin/com/hedvig/libs/logging/masking/MaskedTest.kt
+++ b/logging/src/test/kotlin/com/hedvig/libs/logging/masking/MaskedTest.kt
@@ -3,6 +3,8 @@ package com.hedvig.libs.logging.masking
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import org.junit.Test
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import java.math.BigDecimal
 
 class MaskedTest {
@@ -249,5 +251,22 @@ class MaskedTest {
 
         val d = BigDecimal(12)
         assertThat(d.toMaskedString()).isEqualTo(d.toString())
+    }
+
+    @Test
+    fun testResponseEntity() {
+        data class Child(
+            val a: String,
+            val b: String,
+            @Masked val c: String,
+        )
+
+        val child = Child("a", "2", "masked")
+        val responseEntity = ResponseEntity<Child>(child, HttpStatus.OK)
+
+        assertThat(responseEntity.toMaskedString()).isEqualTo("ResponseEntity(status=200 OK, headers={}, body=Child(a=a, b=2, c=***))")
+
+        val c = ResponseEntity(null, HttpStatus.OK)
+        assertThat(c.toMaskedString()).isEqualTo("ResponseEntity(status=200 OK, headers={}, body=null)")
     }
 }


### PR DESCRIPTION
It is common to log out returned `ResponseEntity` via `@LogCall`. The output is not properly masked.

The `body` of `ResponseEntity` is now masked as it should.