### PR TITLE
Experiment with a different, more concise naming

### DIFF
--- a/translations/pom.xml
+++ b/translations/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>translations</artifactId>
     <packaging>jar</packaging>
-    <version>0.2.0</version>
+    <version>0.3.0</version>
 
     <name>translations</name>
     <description>Shared lib for translations</description>

--- a/translations/src/main/kotlin/com/hedvig/libs/translations/RemoteJsonFileTranslations.kt
+++ b/translations/src/main/kotlin/com/hedvig/libs/translations/RemoteJsonFileTranslations.kt
@@ -9,10 +9,10 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlin.concurrent.timerTask
 
-class RemoteJsonFileTranslationsClient(
+class RemoteJsonFileTranslations(
     private val url: String = "https://s3.eu-central-1.amazonaws.com/translations.hedvig.com/platform/translations.json",
     refreshRateMinutes: Long = 10
-) : TranslationsClient {
+) : Translations {
 
     private val logger = LoggerFactory.getLogger(javaClass)
     private val objectMapper = ObjectMapper()
@@ -56,7 +56,11 @@ class RemoteJsonFileTranslationsClient(
         }
     }
 
-    override fun getTranslation(key: String, locale: Locale): String? {
-        return translationsByLocale[locale.toString()]?.get(key)?.asText()
+    override fun get(key: String, locale: Locale): String? {
+        val translation = translationsByLocale[locale.toString()]?.get(key)?.asText()
+        if (translation.isNullOrEmpty()) {
+            logger.warn("Missing translation for requested key: $key")
+        }
+        return translation
     }
 }

--- a/translations/src/main/kotlin/com/hedvig/libs/translations/Translations.kt
+++ b/translations/src/main/kotlin/com/hedvig/libs/translations/Translations.kt
@@ -1,0 +1,11 @@
+package com.hedvig.libs.translations
+
+import java.util.Locale
+
+/**
+ * A container of localized strings that can be retrieved by key and locale.
+ */
+interface Translations {
+    fun get(key: String, locale: Locale): String?
+}
+

--- a/translations/src/main/kotlin/com/hedvig/libs/translations/TranslationsClient.kt
+++ b/translations/src/main/kotlin/com/hedvig/libs/translations/TranslationsClient.kt
@@ -1,8 +1,0 @@
-package com.hedvig.libs.translations
-
-import java.util.Locale
-
-interface TranslationsClient {
-    fun getTranslation(key: String, locale: Locale): String?
-}
-

--- a/translations/src/test/kotlin/com/hedvig/libs/translations/TranslationsTest.kt
+++ b/translations/src/test/kotlin/com/hedvig/libs/translations/TranslationsTest.kt
@@ -9,30 +9,30 @@ import org.junit.jupiter.api.assertThrows
 import java.io.IOException
 import java.util.Locale
 
-class TranslationsClientTest {
+class TranslationsTest {
 
     @Test
     @Disabled
     // This test can be enabled/run locally when developing, but we don't won't to rely on S3 or specific translation in CI
     fun test() {
         val client =
-            RemoteJsonFileTranslationsClient(
+            RemoteJsonFileTranslations(
                 "https://s3.eu-central-1.amazonaws.com/translations.hedvig.com/platform/translations.json",
                 1
             )
 
-        var translation = client.getTranslation("DK_CONTENT_CONVERSATION_SIZE_TOOLTIP_TITLE", Locale("da", "DK"))
+        var translation = client.get("DK_CONTENT_CONVERSATION_SIZE_TOOLTIP_TITLE", Locale("da", "DK"))
         assertThat(translation).isEqualTo("Størrelse")
 
-        translation = client.getTranslation("DK_CONTENT_CONVERSATION_SIZE_TOOLTIP_TITLE", Locale("en", "DK"))
+        translation = client.get("DK_CONTENT_CONVERSATION_SIZE_TOOLTIP_TITLE", Locale("en", "DK"))
         assertThat(translation).isEqualTo("Size")
 
         // Unsupported text key
-        translation = client.getTranslation("X_WHATEVER_X", Locale("da", "DK"))
+        translation = client.get("X_WHATEVER_X", Locale("da", "DK"))
         assertThat(translation).isNull()
 
         // Unsupported locale
-        translation = client.getTranslation("DK_CONTENT_CONVERSATION_SIZE_TOOLTIP_TITLE", Locale("sv", "DK"))
+        translation = client.get("DK_CONTENT_CONVERSATION_SIZE_TOOLTIP_TITLE", Locale("sv", "DK"))
         assertThat(translation).isNull()
     }
 
@@ -40,7 +40,7 @@ class TranslationsClientTest {
     fun testFailToInit() {
 
         assertThrows<IOException>("Should fail to init") {
-            RemoteJsonFileTranslationsClient("https://234567lkjhgfdzxcvbnj8765.com")
+            RemoteJsonFileTranslations("https://234567lkjhgfdzxcvbnj8765.com")
         }
     }
 }


### PR DESCRIPTION
# Jira Issue: [SC2-6] 

## What?
- Remove the word `Client` from the translations interface
- Instead favour simply `Translations` and `Translations.get(String, Locale)`
- Also add a warning for missing strings

## Why?
- `Client` implies that strings are fetched from somewhere else
- `Translations` is so concise and pretty 🙃 

## Optional checklist
- [x] Codescouted
- [ ] Unit tests written
- [ ] Tested locally

