### PR TITLE
Add log exceptions aspect

### DIFF
--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>logging</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.4</version>
+    <version>1.1.0</version>
 
     <name>logging</name>
     <description>Shared lib for logging utilities</description>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -25,7 +25,6 @@
             <artifactId>spring-boot-starter-aop</artifactId>
             <version>${spring.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -55,6 +54,12 @@
             <artifactId>assertk-jvm</artifactId>
             <version>0.22</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>5.3.8</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/logging/src/main/kotlin/com/hedvig/libs/logging/calls/LogExceptions.kt
+++ b/logging/src/main/kotlin/com/hedvig/libs/logging/calls/LogExceptions.kt
@@ -1,0 +1,5 @@
+package com.hedvig.logging.calls
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class LogExceptions()

--- a/logging/src/main/kotlin/com/hedvig/libs/logging/calls/LogExceptionsAspect.kt
+++ b/logging/src/main/kotlin/com/hedvig/libs/logging/calls/LogExceptionsAspect.kt
@@ -1,0 +1,42 @@
+package com.hedvig.logging.calls
+
+import org.aspectj.lang.JoinPoint
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.annotation.Before
+import org.aspectj.lang.annotation.Pointcut
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+/**
+ * Logs exception parameters for public methods in classes annotated with @LogExceptions.
+ * Intended to be used on subclasses of ResponseEntityExceptionHandler.
+ */
+@Aspect
+@Component
+class LogExceptionsAspect {
+
+    @Pointcut("within(@com.hedvig.logging.calls.LogExceptions *)")
+    fun beanAnnotatedWithLogExceptions() {
+    }
+
+    @Pointcut("execution(public * *(..))")
+    fun publicMethod() {
+    }
+
+    @Pointcut("publicMethod() && beanAnnotatedWithLogExceptions()")
+    fun publicMethodInsideAClassMarkedWithLogExceptions() {
+    }
+
+    @Before("publicMethodInsideAClassMarkedWithLogExceptions()")
+    fun logException(joinPoint: JoinPoint) {
+        joinPoint.args
+            .filterIsInstance<Throwable>()
+            .forEach {
+                logger.error(it.localizedMessage, it)
+            }
+    }
+
+    companion object {
+        val logger = LoggerFactory.getLogger(this::class.java)!!
+    }
+}

--- a/logging/src/test/kotlin/com/hedvig/libs/logging/calls/LogExceptionsTest.kt
+++ b/logging/src/test/kotlin/com/hedvig/libs/logging/calls/LogExceptionsTest.kt
@@ -54,10 +54,9 @@ class LogExceptionsTest {
     fun testNoParamsReturningUnit() {
 
         handler.logException(RuntimeException("Test exception"))
-
         with(logWatcher) {
             assertThat(list.size).isEqualTo(1)
-            assertThat(list[0].level.toString()).isEqualTo("ERROR")
+            assertThat(list[0].level.toString()).isEqualTo("WARN")
             assertThat(list[0].message).isEqualTo("Test exception")
             assertThat(list[0].throwableProxy.stackTraceElementProxyArray.size).isGreaterThan(0)
         }

--- a/logging/src/test/kotlin/com/hedvig/libs/logging/calls/LogExceptionsTest.kt
+++ b/logging/src/test/kotlin/com/hedvig/libs/logging/calls/LogExceptionsTest.kt
@@ -1,0 +1,78 @@
+package com.hedvig.libs.logging.calls
+
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import com.hedvig.libs.logging.mdc.MdcScopeAspect
+import com.hedvig.logging.calls.LogExceptions
+import com.hedvig.logging.calls.LogExceptionsAspect
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.EnableAspectJAutoProxy
+import org.springframework.stereotype.Component
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+@SpringBootTest(classes = [LogExceptionsAspect::class])
+@ComponentScan("com.hedvig.libs.logging.calls")
+@EnableAspectJAutoProxy
+class LogExceptionsTest {
+
+    @Autowired
+    lateinit var handler: ExceptionHandler
+
+    private lateinit var logWatcher: ListAppender<ILoggingEvent>
+
+    @BeforeEach
+    fun setup() {
+        logWatcher = ListAppender()
+        logWatcher.start()
+        (LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) as Logger).addAppender(logWatcher)
+    }
+
+    @AfterEach
+    fun cleanup() {
+        (LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) as Logger).detachAppender(logWatcher)
+    }
+
+    @Test
+    fun testNoLogging() {
+
+        handler.logNothing("asd")
+
+        assertThat(logWatcher.list).isEmpty()
+    }
+
+    @Test
+    fun testNoParamsReturningUnit() {
+
+        handler.logException(RuntimeException("Test exception"))
+
+        with(logWatcher) {
+            assertThat(list.size).isEqualTo(1)
+            assertThat(list[0].level.toString()).isEqualTo("ERROR")
+            assertThat(list[0].message).isEqualTo("Test exception")
+            assertThat(list[0].throwableProxy.stackTraceElementProxyArray.size).isGreaterThan(0)
+        }
+    }
+}
+
+@Component
+@LogExceptions
+class ExceptionHandler {
+
+    fun logNothing(param: String): String {
+        return "APA"
+    }
+
+    fun logException(e: Exception): Exception {
+        return e
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <kotlin.version>1.4.10</kotlin.version>
-        <spring.version>2.1.14.RELEASE</spring.version>
+        <spring.version>2.5.2</spring.version>
         <junit-jupiter.version>5.3.2</junit-jupiter.version>
         <github.global.server>github</github.global.server>
     </properties>


### PR DESCRIPTION
# Jira Issue: [MX-198] 

## What?
- An aspect which logs exception parameters to methods in classes annotated with `@LogExceptions`

## Why?
- To conveniently log exceptions passed to methods in subclasses of `ResponseEntityExceptionHandler`. Exceptions that are handled by such classes are considered to be caught, so the stack trace is not logged, which is a problem when debugging. 

## Optional checklist
- [x] Codescouted
- [x] Unit tests written
- [x] Tested locally



[MX-198]: https://hedvig.atlassian.net/browse/MX-198