### PR TITLE
SC2-2: write a plug-and-play filter that will attach some (configurable) headers in the MDC

### DIFF
--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -25,6 +25,12 @@
             <artifactId>spring-boot-starter-aop</artifactId>
             <version>${spring.version}</version>
         </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>logging</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
 
     <name>logging</name>
     <description>Shared lib for logging utilities</description>

--- a/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/MdcStack.kt
+++ b/logging/src/main/kotlin/com/hedvig/libs/logging/mdc/MdcStack.kt
@@ -1,0 +1,29 @@
+package com.hedvig.libs.logging.mdc
+
+import org.slf4j.MDC
+
+internal class MdcStack(
+    private val previousValues: Map<String, String>,
+    private val newValues: Map<String, String>
+) {
+    companion object {
+        fun push(values: Map<String, String>): MdcStack {
+            val existing = mutableMapOf<String, String>()
+            values.forEach { (key, value) ->
+                MDC.get(key)?.let { existing[key] = it }
+                MDC.put(key, value)
+            }
+            return MdcStack(existing, values)
+        }
+    }
+
+    fun restore() {
+        newValues.forEach { (key, _) ->
+            previousValues[key]?.let { restored ->
+                MDC.put(key, restored)
+            } ?: run {
+                MDC.remove(key)
+            }
+        }
+    }
+}

--- a/logging/src/main/kotlin/com/hedvig/libs/logging/web/HedvigMdcFilter.kt
+++ b/logging/src/main/kotlin/com/hedvig/libs/logging/web/HedvigMdcFilter.kt
@@ -1,0 +1,46 @@
+package com.hedvig.libs.logging.web
+
+import com.hedvig.libs.logging.mdc.MdcStack
+import javax.servlet.Filter
+import javax.servlet.FilterChain
+import javax.servlet.FilterConfig
+import javax.servlet.ServletRequest
+import javax.servlet.ServletResponse
+import javax.servlet.http.HttpServletRequest
+
+class HedvigMdcFilter(
+    private val prefix: String = "hedvig",
+    private val headers: List<Header> = listOf(
+        Header("Hedvig.token", "memberId"),
+        Header("Accept-Language", "locale"),
+    )
+): Filter {
+
+    data class Header(
+        val name: String,
+        val mdcKey: String
+    )
+
+    override fun init(config: FilterConfig) {
+    }
+
+    override fun doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
+        request as HttpServletRequest
+        val context = mutableMapOf<String, String>()
+        for (header in headers) {
+            request.getHeader(header.name)?.let { value ->
+                context["${prefix}.${header.mdcKey}"] = value
+            }
+        }
+
+        val stack = MdcStack.push(context)
+        try {
+            chain.doFilter(request, response)
+        } finally {
+            stack.restore()
+        }
+    }
+
+    override fun destroy() {
+    }
+}

--- a/logging/src/test/kotlin/com/hedvig/libs/logging/LoggingTestsApplication.kt
+++ b/logging/src/test/kotlin/com/hedvig/libs/logging/LoggingTestsApplication.kt
@@ -1,0 +1,8 @@
+package com.hedvig.libs.logging
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.web.servlet.config.annotation.EnableWebMvc
+
+@SpringBootApplication
+@EnableWebMvc
+class LoggingTestsApplication

--- a/logging/src/test/kotlin/com/hedvig/libs/logging/web/HedvigMdcFilterTest.kt
+++ b/logging/src/test/kotlin/com/hedvig/libs/logging/web/HedvigMdcFilterTest.kt
@@ -1,0 +1,126 @@
+package com.hedvig.libs.logging.web
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.containsAll
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isSuccess
+import org.jboss.logging.MDC
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.boot.test.web.client.exchange
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpStatus
+import org.springframework.http.RequestEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+import java.net.URI
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+internal class HedvigMdcFilterTest {
+
+    @Autowired
+    lateinit var template: TestRestTemplate
+
+    @Autowired
+    lateinit var controller: Controller
+
+    @AfterEach
+    fun tearDown(@Autowired controller: Controller) {
+        controller.mdcValues.clear()
+    }
+
+    @Test
+    fun `test 0 context values`() {
+        val request = RequestEntity.get(URI("/test/mdc"))
+            .build()
+        assertThat {
+            template.exchange<Any>(request).statusCode
+        }.isSuccess().isEqualTo(HttpStatus.OK)
+
+        assertThat {
+            controller.mdcValues
+        }.isSuccess().isEmpty()
+    }
+
+    @Test
+    fun `test 1 context value`() {
+        val request = RequestEntity.get(URI("/test/mdc"))
+            .header("Hedvig.token", "12345")
+            .build()
+        assertThat {
+            template.exchange<Any>(request).statusCode
+        }.isSuccess().isEqualTo(HttpStatus.OK)
+
+        assertThat {
+            controller.mdcValues
+        }.isSuccess().contains("hedvig.memberId" to "12345")
+    }
+
+    @Test
+    fun `test 2 context values`() {
+        val request = RequestEntity.get(URI("/test/mdc"))
+            .header("Hedvig.token", "12345")
+            .header("Accept-Language", "sv_SE")
+            .build()
+        assertThat {
+            template.exchange<Any>(request).statusCode
+        }.isSuccess().isEqualTo(HttpStatus.OK)
+
+        assertThat {
+            controller.mdcValues
+        }.isSuccess().containsAll(
+            "hedvig.memberId" to "12345",
+            "hedvig.locale" to "sv_SE",
+        )
+    }
+
+    @Test
+    fun `test context is cleared after request`() {
+        val request1 = RequestEntity.get(URI("/test/mdc"))
+            .header("Hedvig.token", "12345")
+            .build()
+        assertThat {
+            template.exchange<Any>(request1).statusCode
+        }.isSuccess().isEqualTo(HttpStatus.OK)
+        controller.mdcValues.clear()
+
+        // Fire a bunch of requests to hit the same thread again, making sure we get the same
+        // thead-local MDC
+        (0..20).forEach { _ ->
+            val request2 = RequestEntity.get(URI("/test/mdc"))
+                .build()
+            assertThat {
+                template.exchange<Any>(request2).statusCode
+            }.isSuccess().isEqualTo(HttpStatus.OK)
+        }
+
+        assertThat {
+            controller.mdcValues
+        }.isSuccess().isEmpty()
+    }
+}
+
+@Configuration
+class Config {
+    @Bean
+    fun filter() = HedvigMdcFilter()
+}
+
+@RestController
+class Controller {
+
+    val mdcValues = mutableSetOf<Pair<String, Any>>()
+
+    @GetMapping("/test/mdc")
+    fun mdcTest() {
+        MDC.getMap().forEach { (key, value) ->
+            mdcValues.add(key to value)
+        }
+    }
+}


### PR DESCRIPTION
# Jira Issue: [SC2-2] 

## What?
- Adds a `Filter` that can be attached to the application context that will put some request headers in the MDC under a prefix

### Usage

```kotlin
@Configuration
class LoggingConfiguration {
  @Bean
  fun mdcFilter() = HedvigMdcFilter()
}
```

## Why?
- Automatically having some structured context in all requests is super-powerful when searching for errors
- Request headers are a great candidate for these kinds of values

## Future work
- The clients should send even more headers with context

## Optional checklist
- [x] Codescouted
- [x] Unit tests written
- [ ] Tested locally

