### PR TITLE
Bumped jackson-databind due to security CVEs

### DIFF
--- a/translations/pom.xml
+++ b/translations/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.4</version>
+            <version>2.9.10.8</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## What?
- Bumped `jackson-databind`, GitHub complaining on CVEs with old version.
